### PR TITLE
CC-1222: update cpp version, and add vcpkg support for dependency resolution

### DIFF
--- a/compiled_starters/cpp/.gitignore
+++ b/compiled_starters/cpp/.gitignore
@@ -44,3 +44,6 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+
+build/
+vcpkg_installed

--- a/compiled_starters/cpp/CMakeLists.txt
+++ b/compiled_starters/cpp/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
+
 project(sqlite-starter-cpp)
-set(CMAKE_CXX_STANDARD 20) # Enable the C++20 standard
+
+set(CMAKE_CXX_STANDARD 23) # Enable the C++23 standard
 
 file(GLOB_RECURSE SOURCE_FILES src/*.cpp)
 

--- a/compiled_starters/cpp/codecrafters.yml
+++ b/compiled_starters/cpp/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the C++ version used to run your code
 # on Codecrafters.
 #
-# Available versions: cpp-20
-language_pack: cpp-20
+# Available versions: cpp-23
+language_pack: cpp-23

--- a/compiled_starters/cpp/vcpkg-configuration.json
+++ b/compiled_starters/cpp/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+    "default-registry": {
+        "kind": "git",
+        "baseline": "c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d",
+        "repository": "https://github.com/microsoft/vcpkg"
+    },
+    "registries": [
+        {
+            "kind": "artifact",
+            "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+            "name": "microsoft"
+        }
+    ]
+}

--- a/compiled_starters/cpp/vcpkg.json
+++ b/compiled_starters/cpp/vcpkg.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": []
+}

--- a/compiled_starters/cpp/your_sqlite3.sh
+++ b/compiled_starters/cpp/your_sqlite3.sh
@@ -6,6 +6,7 @@
 #
 # DON'T EDIT THIS!
 set -e
-cmake $(dirname $0) > /dev/null
-make > /dev/null
-exec ./server "$@"
+# vcpkg & cmake are required. 
+cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
+cmake --build ./build
+exec ./build/server "$@"

--- a/dockerfiles/cpp-23.Dockerfile
+++ b/dockerfiles/cpp-23.Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM gcc:13.2.0-bookworm
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="vcpkg.json,vcpkg-configuration.json"
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y zip=3.* && \ 
+    apt-get install --no-install-recommends -y g++=4:* && \
+    apt-get install --no-install-recommends -y build-essential=12.* && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# cmake 3.29.2 is required by vcpkg
+RUN wget --progress=dot:giga https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-Linux-x86_64.tar.gz && \
+    tar -xzvf cmake-3.29.2-Linux-x86_64.tar.gz && \
+    mv cmake-3.29.2-linux-x86_64/ /cmake
+
+ENV CMAKE_BIN="/cmake/bin"
+ENV PATH="${CMAKE_BIN}:$PATH"
+
+RUN git clone https://github.com/microsoft/vcpkg.git && \
+    ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+
+ENV VCPKG_ROOT="/vcpkg"
+ENV PATH="${VCPKG_ROOT}:$PATH"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+RUN vcpkg install --no-print-usage
+RUN sed -i '1s/^/set(VCPKG_INSTALL_OPTIONS --no-print-usage)\n/' ${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
+
+RUN mkdir -p /app-cached/build
+RUN if [ -d "/app/build" ]; then mv /app/build /app-cached; fi
+RUN if [ -d "/app/vcpkg_installed" ]; then mv /app/vcpkg_installed /app-cached/build; fi
+
+RUN echo "cd \${CODECRAFTERS_SUBMISSION_DIR} && cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake && cmake --build ./build && sed -i '/^cmake/ s/^/# /' ./your_sqlite3.sh" > /codecrafters-precompile.sh
+RUN chmod +x /codecrafters-precompile.sh
+
+# Once the heavy steps are done, we can copy all files back
+COPY . /app

--- a/solutions/cpp/01-dr6/code/.gitignore
+++ b/solutions/cpp/01-dr6/code/.gitignore
@@ -44,3 +44,6 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+
+build/
+vcpkg_installed

--- a/solutions/cpp/01-dr6/code/CMakeLists.txt
+++ b/solutions/cpp/01-dr6/code/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
+
 project(sqlite-starter-cpp)
-set(CMAKE_CXX_STANDARD 20) # Enable the C++20 standard
+
+set(CMAKE_CXX_STANDARD 23) # Enable the C++23 standard
 
 file(GLOB_RECURSE SOURCE_FILES src/*.cpp)
 

--- a/solutions/cpp/01-dr6/code/codecrafters.yml
+++ b/solutions/cpp/01-dr6/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the C++ version used to run your code
 # on Codecrafters.
 #
-# Available versions: cpp-20
-language_pack: cpp-20
+# Available versions: cpp-23
+language_pack: cpp-23

--- a/solutions/cpp/01-dr6/code/vcpkg-configuration.json
+++ b/solutions/cpp/01-dr6/code/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+    "default-registry": {
+        "kind": "git",
+        "baseline": "c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d",
+        "repository": "https://github.com/microsoft/vcpkg"
+    },
+    "registries": [
+        {
+            "kind": "artifact",
+            "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+            "name": "microsoft"
+        }
+    ]
+}

--- a/solutions/cpp/01-dr6/code/vcpkg.json
+++ b/solutions/cpp/01-dr6/code/vcpkg.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": []
+}

--- a/solutions/cpp/01-dr6/code/your_sqlite3.sh
+++ b/solutions/cpp/01-dr6/code/your_sqlite3.sh
@@ -6,6 +6,7 @@
 #
 # DON'T EDIT THIS!
 set -e
-cmake $(dirname $0) > /dev/null
-make > /dev/null
-exec ./server "$@"
+# vcpkg & cmake are required. 
+cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
+cmake --build ./build
+exec ./build/server "$@"

--- a/starter-repository-definitions.yml
+++ b/starter-repository-definitions.yml
@@ -196,6 +196,10 @@
       target: src/Server.cpp
     - source: starter_templates/cpp/CMakeLists.txt
       target: CMakeLists.txt
+    - source: starter_templates/cpp/vcpkg.json
+      target: vcpkg.json
+    - source: starter_templates/cpp/vcpkg-configuration.json
+      target: vcpkg-configuration.json
     - source: starter_templates/cpp/your_sqlite3.sh
       target: your_sqlite3.sh
     - source: starter_templates/.gitattributes

--- a/starter_templates/codecrafters.yml
+++ b/starter_templates/codecrafters.yml
@@ -72,8 +72,8 @@ language_pack: clojure-1.10.3
 language_pack: dotnet-8.0
 {{/language_is_csharp}}
 {{#language_is_cpp}}
-# Available versions: cpp-20
-language_pack: cpp-20
+# Available versions: cpp-23
+language_pack: cpp-23
 {{/language_is_cpp}}
 {{#language_is_zig}}
 # Available versions: zig-0.12

--- a/starter_templates/cpp/.gitignore
+++ b/starter_templates/cpp/.gitignore
@@ -44,3 +44,6 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+
+build/
+vcpkg_installed

--- a/starter_templates/cpp/CMakeLists.txt
+++ b/starter_templates/cpp/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
+
 project(sqlite-starter-cpp)
-set(CMAKE_CXX_STANDARD 20) # Enable the C++20 standard
+
+set(CMAKE_CXX_STANDARD 23) # Enable the C++23 standard
 
 file(GLOB_RECURSE SOURCE_FILES src/*.cpp)
 

--- a/starter_templates/cpp/vcpkg-configuration.json
+++ b/starter_templates/cpp/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+    "default-registry": {
+        "kind": "git",
+        "baseline": "c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d",
+        "repository": "https://github.com/microsoft/vcpkg"
+    },
+    "registries": [
+        {
+            "kind": "artifact",
+            "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+            "name": "microsoft"
+        }
+    ]
+}

--- a/starter_templates/cpp/vcpkg.json
+++ b/starter_templates/cpp/vcpkg.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": []
+}

--- a/starter_templates/cpp/your_sqlite3.sh
+++ b/starter_templates/cpp/your_sqlite3.sh
@@ -6,6 +6,7 @@
 #
 # DON'T EDIT THIS!
 set -e
-cmake $(dirname $0) > /dev/null
-make > /dev/null
-exec ./server "$@"
+# vcpkg & cmake are required. 
+cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake
+cmake --build ./build
+exec ./build/server "$@"


### PR DESCRIPTION
Update C++ version support to 23.
Add vcpkg for dependency resolution.
Build process also includes repository-aware caching now.