### PR TITLE
Upgrade Go to 1.24

### DIFF
--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `go (1.16+)` installed locally
+1. Ensure you have `go (1.24)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.go`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/go/codecrafters.yml
+++ b/compiled_starters/go/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Go version used to run your code
 # on Codecrafters.
 #
-# Available versions: go-1.22
-language_pack: go-1.22
+# Available versions: go-1.24
+language_pack: go-1.24

--- a/compiled_starters/go/go.mod
+++ b/compiled_starters/go/go.mod
@@ -6,8 +6,8 @@
 //
 // DON'T EDIT THIS!
 
-module github/com/codecrafters-io/sqlite-starter-go
+module github.com/codecrafters-io/sqlite-starter-go
 
-go 1.22
+go 1.24.0
 
 require github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2

--- a/dockerfiles/go-1.24.Dockerfile
+++ b/dockerfiles/go-1.24.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.7-labs
-FROM golang:1.22-alpine
+FROM golang:1.24-alpine
 
 # Ensures the container is re-built if go.mod or go.sum changes
 ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="go.mod,go.sum"

--- a/solutions/go/01-dr6/code/README.md
+++ b/solutions/go/01-dr6/code/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `go (1.16+)` installed locally
+1. Ensure you have `go (1.24)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.go`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/go/01-dr6/code/codecrafters.yml
+++ b/solutions/go/01-dr6/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Go version used to run your code
 # on Codecrafters.
 #
-# Available versions: go-1.22
-language_pack: go-1.22
+# Available versions: go-1.24
+language_pack: go-1.24

--- a/solutions/go/01-dr6/code/go.mod
+++ b/solutions/go/01-dr6/code/go.mod
@@ -6,8 +6,8 @@
 //
 // DON'T EDIT THIS!
 
-module github/com/codecrafters-io/sqlite-starter-go
+module github.com/codecrafters-io/sqlite-starter-go
 
-go 1.22
+go 1.24.0
 
 require github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2

--- a/starter_templates/go/code/go.mod
+++ b/starter_templates/go/code/go.mod
@@ -6,8 +6,8 @@
 //
 // DON'T EDIT THIS!
 
-module github/com/codecrafters-io/sqlite-starter-go
+module github.com/codecrafters-io/sqlite-starter-go
 
-go 1.22
+go 1.24.0
 
 require github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2

--- a/starter_templates/go/config.yml
+++ b/starter_templates/go/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: go (1.16+)
+  required_executable: go (1.24)
   user_editable_file: app/main.go


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated all installation instructions and requirements to mandate Go 1.24 for a consistent user experience.

- **Chores**
  - Improved container build configurations to optimize dependency management and reduce caching issues.
  - Corrected configuration inconsistencies and module declarations to align with the new Go version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->