### PR TITLE
Refactor stdout handling in Zig main function to use streaming writer

### DIFF
--- a/compiled_starters/zig/src/main.zig
+++ b/compiled_starters/zig/src/main.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
-var stdout_buffer: [1024]u8 = undefined;
-var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-const stdout = &stdout_writer.interface;
+var stdout_reader = std.fs.File.stdout().writerStreaming(&.{});
+const stdout = &stdout_reader.interface;
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -12,7 +11,7 @@ pub fn main() !void {
     defer std.process.argsFree(allocator, args);
 
     if (args.len < 3) {
-        std.debug.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
+        try stdout.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
         std.process.exit(1);
     }
 
@@ -32,6 +31,5 @@ pub fn main() !void {
         // _ = try file.read(&buf);
         // const page_size = std.mem.readInt(u16, &buf, .big);
         // try stdout.print("database page size: {}\n", .{page_size});
-        // try stdout.flush();
     }
 }

--- a/solutions/zig/01-dr6/code/src/main.zig
+++ b/solutions/zig/01-dr6/code/src/main.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
-var stdout_buffer: [1024]u8 = undefined;
-var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-const stdout = &stdout_writer.interface;
+var stdout_reader = std.fs.File.stdout().writerStreaming(&.{});
+const stdout = &stdout_reader.interface;
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -12,7 +11,7 @@ pub fn main() !void {
     defer std.process.argsFree(allocator, args);
 
     if (args.len < 3) {
-        std.debug.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
+        try stdout.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
         std.process.exit(1);
     }
 
@@ -28,6 +27,5 @@ pub fn main() !void {
         _ = try file.read(&buf);
         const page_size = std.mem.readInt(u16, &buf, .big);
         try stdout.print("database page size: {}\n", .{page_size});
-        try stdout.flush();
     }
 }

--- a/solutions/zig/01-dr6/diff/src/main.zig.diff
+++ b/solutions/zig/01-dr6/diff/src/main.zig.diff
@@ -1,8 +1,7 @@
-@@ -1,37 +1,33 @@
+@@ -1,35 +1,31 @@
  const std = @import("std");
- var stdout_buffer: [1024]u8 = undefined;
- var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
- const stdout = &stdout_writer.interface;
+ var stdout_reader = std.fs.File.stdout().writerStreaming(&.{});
+ const stdout = &stdout_reader.interface;
 
  pub fn main() !void {
      var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -13,7 +12,7 @@
      defer std.process.argsFree(allocator, args);
 
      if (args.len < 3) {
-         std.debug.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
+         try stdout.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
          std.process.exit(1);
      }
 
@@ -33,12 +32,10 @@
 -        // _ = try file.read(&buf);
 -        // const page_size = std.mem.readInt(u16, &buf, .big);
 -        // try stdout.print("database page size: {}\n", .{page_size});
--        // try stdout.flush();
 +        var buf: [2]u8 = undefined;
 +        _ = try file.seekTo(16);
 +        _ = try file.read(&buf);
 +        const page_size = std.mem.readInt(u16, &buf, .big);
 +        try stdout.print("database page size: {}\n", .{page_size});
-+        try stdout.flush();
      }
  }

--- a/solutions/zig/01-dr6/explanation.md
+++ b/solutions/zig/01-dr6/explanation.md
@@ -9,7 +9,6 @@ _ = try file.seekTo(16);
 _ = try file.read(&buf);
 const page_size = std.mem.readInt(u16, &buf, .big);
 try stdout.print("database page size: {}\n", .{page_size});
-try stdout.flush();
 ```
 
 Push your changes to pass the first stage:

--- a/starter_templates/zig/code/src/main.zig
+++ b/starter_templates/zig/code/src/main.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
-var stdout_buffer: [1024]u8 = undefined;
-var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-const stdout = &stdout_writer.interface;
+var stdout_reader = std.fs.File.stdout().writerStreaming(&.{});
+const stdout = &stdout_reader.interface;
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -12,7 +11,7 @@ pub fn main() !void {
     defer std.process.argsFree(allocator, args);
 
     if (args.len < 3) {
-        std.debug.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
+        try stdout.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
         std.process.exit(1);
     }
 
@@ -32,6 +31,5 @@ pub fn main() !void {
         // _ = try file.read(&buf);
         // const page_size = std.mem.readInt(u16, &buf, .big);
         // try stdout.print("database page size: {}\n", .{page_size});
-        // try stdout.flush();
     }
 }


### PR DESCRIPTION
- Updated stdout initialization to use writerStreaming for improved performance.
- Changed usage message output from std.debug.print to stdout.print for consistency.
- Removed unnecessary flush calls to streamline the code.