### PR TITLE
CC-2075: Update Rust to 1.92

### DIFF
--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.91)` installed locally
+1. Ensure you have `cargo (1.92)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.91
-buildpack: rust-1.91
+# Available versions: rust-1.92
+buildpack: rust-1.92

--- a/dockerfiles/rust-1.92.Dockerfile
+++ b/dockerfiles/rust-1.92.Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM rust:1.92-trixie
+
+# Rebuild the container if these files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs cargo build
+RUN .codecrafters/compile.sh

--- a/solutions/rust/01-dr6/code/README.md
+++ b/solutions/rust/01-dr6/code/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.91)` installed locally
+1. Ensure you have `cargo (1.92)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-dr6/code/codecrafters.yml
+++ b/solutions/rust/01-dr6/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.91
-buildpack: rust-1.91
+# Available versions: rust-1.92
+buildpack: rust-1.92

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.91)
+  required_executable: cargo (1.92)
   user_editable_file: src/main.rs


### PR DESCRIPTION
CC-2075: Update Rust to 1.92

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades the Rust toolchain across templates and build configs to 1.92.
> 
> - Updates `codecrafters.yml` buildpack from `rust-1.91` to `rust-1.92` (compiled starters and solution)
> - Bumps local requirement from `cargo (1.91)` to `cargo (1.92)` in `README.md` files and `starter_templates/rust/config.yml`
> - Adds `dockerfiles/rust-1.92.Dockerfile` based on `rust:1.92-trixie` to compile projects
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit afb30660d1b502346e4c9f7c333b39f89d9d10c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->