### PR TITLE
CC-2114: Upgrade Gleam to v1.14

### DIFF
--- a/compiled_starters/gleam/README.md
+++ b/compiled_starters/gleam/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `gleam (1.13.0)` installed locally
+1. Ensure you have `gleam (1.14.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.gleam`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/gleam/codecrafters.yml
+++ b/compiled_starters/gleam/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.13
-buildpack: gleam-1.13
+# Available versions: gleam-1.14
+buildpack: gleam-1.14

--- a/dockerfiles/gleam-1.14.Dockerfile
+++ b/dockerfiles/gleam-1.14.Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM ghcr.io/gleam-lang/gleam:v1.14.0-erlang-alpine
+
+# Rebuild if gleam.toml or manifest.toml change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="gleam.toml,manifest.toml"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Force deps to be downloaded
+RUN gleam build
+
+# Cache build directory
+RUN mkdir -p /app-cached
+RUN mv build /app-cached/build

--- a/solutions/gleam/01-dr6/code/README.md
+++ b/solutions/gleam/01-dr6/code/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `gleam (1.13.0)` installed locally
+1. Ensure you have `gleam (1.14.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.gleam`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/gleam/01-dr6/code/codecrafters.yml
+++ b/solutions/gleam/01-dr6/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.13
-buildpack: gleam-1.13
+# Available versions: gleam-1.14
+buildpack: gleam-1.14

--- a/starter_templates/gleam/config.yml
+++ b/starter_templates/gleam/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: gleam (1.13.0)
+  required_executable: gleam (1.14.0)
   user_editable_file: src/main.gleam


### PR DESCRIPTION
CC-2114: Upgrade Gleam to v1.14

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrades the Gleam version used across starters and solutions to 1.14 and introduces a corresponding build image.
> 
> - Update `codecrafters.yml` to use `gleam-1.14` (compiled starter and solution)
> - Update README instructions and `starter_templates/gleam/config.yml` to require `gleam (1.14.0)`
> - Add `dockerfiles/gleam-1.14.Dockerfile` based on `v1.14.0-erlang-alpine` with dependency caching
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f608cab19e79a6273cac1d968e328d3f1fedf45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->