### PR TITLE
CC-2144: Upgrade Rust to v1.93

### DIFF
--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.92)` installed locally
+1. Ensure you have `cargo (1.93)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.92
-buildpack: rust-1.92
+# Available versions: rust-1.93
+buildpack: rust-1.93

--- a/dockerfiles/rust-1.93.Dockerfile
+++ b/dockerfiles/rust-1.93.Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM rust:1.93-trixie
+
+# Rebuild the container if these files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs cargo build
+RUN .codecrafters/compile.sh

--- a/solutions/rust/01-dr6/code/README.md
+++ b/solutions/rust/01-dr6/code/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.92)` installed locally
+1. Ensure you have `cargo (1.93)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-dr6/code/codecrafters.yml
+++ b/solutions/rust/01-dr6/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.92
-buildpack: rust-1.92
+# Available versions: rust-1.93
+buildpack: rust-1.93

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.92)
+  required_executable: cargo (1.93)
   user_editable_file: src/main.rs


### PR DESCRIPTION
CC-2144: Upgrade Rust to v1.93

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly version bumps and a new Dockerfile; main risk is compatibility/build failures if any starter code or dependencies rely on Rust 1.92 behavior.
> 
> **Overview**
> Upgrades the Rust starter/solution environment from **Rust 1.92 to 1.93** by updating the documented local `cargo` requirement and switching `codecrafters.yml` to `buildpack: rust-1.93`.
> 
> Adds a new `dockerfiles/rust-1.93.Dockerfile` to build/test starters against Rust 1.93 (running `.codecrafters/compile.sh` during image build).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ecf313ed707580c1b205e0bbf436f1517328fca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->