### PR TITLE
CC-2161: Upgrade go to v1.26

### DIFF
--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `go (1.25)` installed locally
+1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.go`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/go/codecrafters.yml
+++ b/compiled_starters/go/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Go version used to run your code
 # on Codecrafters.
 #
-# Available versions: go-1.25
-buildpack: go-1.25
+# Available versions: go-1.26
+buildpack: go-1.26

--- a/compiled_starters/go/go.mod
+++ b/compiled_starters/go/go.mod
@@ -1,5 +1,5 @@
 module github.com/codecrafters-io/sqlite-starter-go
 
-go 1.25.0
+go 1.26.0
 
 require github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2

--- a/dockerfiles/go-1.26.Dockerfile
+++ b/dockerfiles/go-1.26.Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM golang:1.26-alpine
+
+# Ensures the container is re-built if go.mod or go.sum changes
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="go.mod,go.sum"
+
+RUN apk add --no-cache --upgrade 'bash>=5.3'
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Starting from Go 1.20, the go standard library is no loger compiled.
+# Setting GODEBUG to "installgoroot=all" restores the old behavior
+# hadolint ignore=DL3062
+RUN GODEBUG="installgoroot=all" go install std
+
+RUN go mod download

--- a/solutions/go/01-dr6/code/README.md
+++ b/solutions/go/01-dr6/code/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `go (1.25)` installed locally
+1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.go`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/go/01-dr6/code/codecrafters.yml
+++ b/solutions/go/01-dr6/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Go version used to run your code
 # on Codecrafters.
 #
-# Available versions: go-1.25
-buildpack: go-1.25
+# Available versions: go-1.26
+buildpack: go-1.26

--- a/solutions/go/01-dr6/code/go.mod
+++ b/solutions/go/01-dr6/code/go.mod
@@ -1,5 +1,5 @@
 module github.com/codecrafters-io/sqlite-starter-go
 
-go 1.25.0
+go 1.26.0
 
 require github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2

--- a/starter_templates/go/code/go.mod
+++ b/starter_templates/go/code/go.mod
@@ -1,5 +1,5 @@
 module github.com/codecrafters-io/sqlite-starter-go
 
-go 1.25.0
+go 1.26.0
 
 require github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2

--- a/starter_templates/go/config.yml
+++ b/starter_templates/go/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: go (1.25)
+  required_executable: go (1.26)
   user_editable_file: app/main.go


### PR DESCRIPTION
CC-2161: Upgrade go to v1.26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Toolchain upgrade can introduce build/runtime differences or dependency incompatibilities in the starter and CI/buildpack environments, but no application logic changes are included.
> 
> **Overview**
> Upgrades the Go starter to **Go 1.26** by updating `go.mod`, `codecrafters.yml` buildpack selection, and documentation/version requirements across compiled starters, templates, and the included solution.
> 
> Adds a new `dockerfiles/go-1.26.Dockerfile` to build/run the environment on Go 1.26 (while leaving the existing Go 1.25 Dockerfile intact).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fc5e28fcd9bd61a0d76a3d1d4a96b2e8a673c17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->