### PR TITLE
CC-2146: Upgrade node to v25

### DIFF
--- a/compiled_starters/javascript/.codecrafters/run.sh
+++ b/compiled_starters/javascript/.codecrafters/run.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-exec node app/main.js "$@"
+NODE_PATH="$(dirname "$0")/node_modules" \
+exec node "$(dirname "$0")/app/main.js" "$@"

--- a/compiled_starters/javascript/.gitignore
+++ b/compiled_starters/javascript/.gitignore
@@ -1,5 +1,5 @@
 # Database files used for testing
 *.db
 
-# node_modules doesn't need to be committed to source control
+# Dependency directories
 node_modules/

--- a/compiled_starters/javascript/README.md
+++ b/compiled_starters/javascript/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `node (21)` installed locally
+1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.js`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/javascript/codecrafters.yml
+++ b/compiled_starters/javascript/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the JavaScript version used to run your code
 # on Codecrafters.
 #
-# Available versions: nodejs-21
-buildpack: nodejs-21
+# Available versions: nodejs-25
+buildpack: nodejs-25

--- a/compiled_starters/javascript/package-lock.json
+++ b/compiled_starters/javascript/package-lock.json
@@ -1,4 +1,3 @@
-
 {
     "name": "@codecrafters/build-your-own-sqlite",
     "version": "1.0.0",

--- a/compiled_starters/javascript/your_program.sh
+++ b/compiled_starters/javascript/your_program.sh
@@ -12,4 +12,5 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec node app/main.js "$@"
+NODE_PATH="$(dirname "$0")/node_modules" \
+exec node "$(dirname "$0")/app/main.js" "$@"

--- a/dockerfiles/nodejs-25.Dockerfile
+++ b/dockerfiles/nodejs-25.Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM node:25-alpine3.23
+
+# Ensures the container is re-built if dependency files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="package.json,package-lock.json"
+
+RUN apk add --no-cache --upgrade 'bash>=5.3'
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Install deps
+RUN npm ci
+
+# If the node_modules directory exists, move it to /app-cached
+RUN mkdir -p /app-cached
+RUN if [ -d "/app/node_modules" ]; then mv /app/node_modules /app-cached; fi

--- a/solutions/javascript/01-dr6/code/.codecrafters/run.sh
+++ b/solutions/javascript/01-dr6/code/.codecrafters/run.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-exec node app/main.js "$@"
+NODE_PATH="$(dirname "$0")/node_modules" \
+exec node "$(dirname "$0")/app/main.js" "$@"

--- a/solutions/javascript/01-dr6/code/.gitignore
+++ b/solutions/javascript/01-dr6/code/.gitignore
@@ -1,5 +1,5 @@
 # Database files used for testing
 *.db
 
-# node_modules doesn't need to be committed to source control
+# Dependency directories
 node_modules/

--- a/solutions/javascript/01-dr6/code/README.md
+++ b/solutions/javascript/01-dr6/code/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `node (21)` installed locally
+1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.js`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/javascript/01-dr6/code/codecrafters.yml
+++ b/solutions/javascript/01-dr6/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the JavaScript version used to run your code
 # on Codecrafters.
 #
-# Available versions: nodejs-21
-buildpack: nodejs-21
+# Available versions: nodejs-25
+buildpack: nodejs-25

--- a/solutions/javascript/01-dr6/code/package-lock.json
+++ b/solutions/javascript/01-dr6/code/package-lock.json
@@ -1,4 +1,3 @@
-
 {
     "name": "@codecrafters/build-your-own-sqlite",
     "version": "1.0.0",

--- a/solutions/javascript/01-dr6/code/your_program.sh
+++ b/solutions/javascript/01-dr6/code/your_program.sh
@@ -12,4 +12,5 @@ set -e # Exit early if any commands fail
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec node app/main.js "$@"
+NODE_PATH="$(dirname "$0")/node_modules" \
+exec node "$(dirname "$0")/app/main.js" "$@"

--- a/starter_templates/javascript/code/.codecrafters/run.sh
+++ b/starter_templates/javascript/code/.codecrafters/run.sh
@@ -8,4 +8,5 @@
 
 set -e # Exit on failure
 
-exec node app/main.js "$@"
+NODE_PATH="$(dirname "$0")/node_modules" \
+exec node "$(dirname "$0")/app/main.js" "$@"

--- a/starter_templates/javascript/code/.gitignore
+++ b/starter_templates/javascript/code/.gitignore
@@ -1,2 +1,2 @@
-# node_modules doesn't need to be committed to source control
+# Dependency directories
 node_modules/

--- a/starter_templates/javascript/code/package-lock.json
+++ b/starter_templates/javascript/code/package-lock.json
@@ -1,4 +1,3 @@
-
 {
     "name": "@codecrafters/build-your-own-sqlite",
     "version": "1.0.0",

--- a/starter_templates/javascript/config.yml
+++ b/starter_templates/javascript/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: node (21)
+  required_executable: node (25)
   user_editable_file: app/main.js


### PR DESCRIPTION
CC-2146: Upgrade node to v25

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrading the Node runtime and build container can surface dependency/runtime incompatibilities and subtle behavior changes across environments. Script changes to `NODE_PATH`/path resolution also affect how modules are located when running from different working directories.
> 
> **Overview**
> Upgrades the JavaScript starter/runtime from **Node 21 to Node 25** by switching `codecrafters.yml`/template requirements and adding a new `dockerfiles/nodejs-25.Dockerfile`.
> 
> Updates local/remote run scripts (`.codecrafters/run.sh`, `your_program.sh`) to set `NODE_PATH` and invoke `app/main.js` via an absolute path (relative to the script), improving reliability when executed outside the repo root. Minor housekeeping updates `.gitignore` wording and normalizes `package-lock.json` formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 198b9fe9175d933e58607c53fa2c8ea8eb6d97d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->