### PR TITLE
CC-2260: Upgrade Rust to v1.95

### DIFF
--- a/compiled_starters/rust/Cargo.toml
+++ b/compiled_starters/rust/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-sqlite"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.94)` installed locally
+1. Ensure you have `cargo (1.95)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/compiled_starters/rust/codecrafters.yml
+++ b/compiled_starters/rust/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.94
-buildpack: rust-1.94
+# Available versions: rust-1.95
+buildpack: rust-1.95

--- a/dockerfiles/rust-1.95.Dockerfile
+++ b/dockerfiles/rust-1.95.Dockerfile
@@ -1,0 +1,13 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM rust:1.95-trixie
+
+# Rebuild the container if these files change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="Cargo.toml,Cargo.lock"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs cargo build
+RUN .codecrafters/compile.sh

--- a/solutions/rust/01-dr6/code/Cargo.toml
+++ b/solutions/rust/01-dr6/code/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-sqlite"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/solutions/rust/01-dr6/code/README.md
+++ b/solutions/rust/01-dr6/code/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `cargo (1.94)` installed locally
+1. Ensure you have `cargo (1.95)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.

--- a/solutions/rust/01-dr6/code/codecrafters.yml
+++ b/solutions/rust/01-dr6/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Rust version used to run your code
 # on Codecrafters.
 #
-# Available versions: rust-1.94
-buildpack: rust-1.94
+# Available versions: rust-1.95
+buildpack: rust-1.95

--- a/starter_templates/rust/code/Cargo.toml
+++ b/starter_templates/rust/code/Cargo.toml
@@ -3,7 +3,7 @@ name = "codecrafters-sqlite"
 version = "0.1.0"
 authors = ["Codecrafters <hello@codecrafters.io>"]
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 
 [dependencies]
 anyhow = "1.0.68"                                # error handling

--- a/starter_templates/rust/config.yml
+++ b/starter_templates/rust/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: cargo (1.94)
+  required_executable: cargo (1.95)
   user_editable_file: src/main.rs


### PR DESCRIPTION
CC-2260: Upgrade Rust to v1.95

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a toolchain/buildpack version bump with no runtime logic changes; main risk is CI/build compatibility or new compiler warnings/errors under Rust 1.95.
> 
> **Overview**
> Upgrades the Rust starter/solution templates to **Rust 1.95** by bumping `rust-version` in `Cargo.toml`, updating local setup instructions (`README.md`), and switching `codecrafters.yml` buildpacks from `rust-1.94` to `rust-1.95`.
> 
> Adds a new `dockerfiles/rust-1.95.Dockerfile` to build/run submissions on the Rust 1.95 base image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3a1416280d836dfda3d15ee4ff6ec9cc11348e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->