### PR TITLE
CC-2191: Upgrade Ruby to v4

### DIFF
--- a/compiled_starters/ruby/Gemfile.lock
+++ b/compiled_starters/ruby/Gemfile.lock
@@ -6,10 +6,10 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
-  x86_64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10

--- a/solutions/ruby/01-dr6/code/Gemfile.lock
+++ b/solutions/ruby/01-dr6/code/Gemfile.lock
@@ -6,10 +6,10 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
-  x86_64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10

--- a/starter_templates/ruby/code/Gemfile.lock
+++ b/starter_templates/ruby/code/Gemfile.lock
@@ -6,10 +6,10 @@ PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
   arm64-darwin-23
-  x86_64-linux
   ruby
+  x86_64-linux
 
 DEPENDENCIES
 
 BUNDLED WITH
-   2.5.6
+  4.0.10


### PR DESCRIPTION
CC-2191: Upgrade Ruby to v4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only changes updating the `BUNDLED WITH` version; low risk unless downstream environments still rely on the older Bundler.
> 
> **Overview**
> Updates Ruby `Gemfile.lock` files in compiled starter, template, and solution to use **Bundler `4.0.10`** (from `2.5.6`) and normalizes the `PLATFORMS` list ordering (ensuring `x86_64-linux` is included).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb7f6b866714c2b0f2c062d2be536c49320b1467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->