### PR TITLE
CC-2208: Upgrade Zig to 0.16

### DIFF
--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `zig (0.15)` installed locally
+1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.zig`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/compiled_starters/zig/build.zig.zon
+++ b/compiled_starters/zig/build.zig.zon
@@ -9,7 +9,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/compiled_starters/zig/codecrafters.yml
+++ b/compiled_starters/zig/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Zig version used to run your code
 # on Codecrafters.
 #
-# Available versions: zig-0.15.2
-buildpack: zig-0.15.2
+# Available versions: zig-0.16
+buildpack: zig-0.16

--- a/compiled_starters/zig/src/main.zig
+++ b/compiled_starters/zig/src/main.zig
@@ -1,18 +1,13 @@
 const std = @import("std");
-var stdout_buffer: [1024]u8 = undefined;
-var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-const stdout = &stdout_writer.interface;
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    var stderr = std.Io.File.stderr().writer(io, &.{});
 
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+    const args = try std.process.Args.toSlice(init.minimal.args, init.arena.allocator());
 
     if (args.len < 3) {
-        std.debug.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
+        try stderr.interface.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
         std.process.exit(1);
     }
 
@@ -20,18 +15,20 @@ pub fn main() !void {
     const command: []const u8 = args[2];
 
     if (std.mem.eql(u8, command, ".dbinfo")) {
-        var file = try std.fs.cwd().openFile(database_file_path, .{});
-        defer file.close();
+        var file = try std.Io.Dir.cwd().openFile(io, database_file_path, .{});
+        defer file.close(io);
 
         // You can use print statements as follows for debugging, they'll be visible when running tests.
-        std.debug.print("Logs from your program will appear here!\n", .{});
+        try stderr.interface.print("Logs from your program will appear here!\n", .{});
 
         // TODO: Uncomment the code below to pass the first stage
-        // var buf: [2]u8 = undefined;
-        // _ = try file.seekTo(16);
-        // _ = try file.read(&buf);
-        // const page_size = std.mem.readInt(u16, &buf, .big);
-        // try stdout.print("database page size: {}\n", .{page_size});
-        // try stdout.flush();
+        //
+        // var reader_buf: [4096]u8 = undefined;
+        // var reader = file.reader(io, &reader_buf);
+        // try reader.seekTo(16);
+        // const page_size = std.mem.readInt(u16, try reader.interface.takeArray(2), .big);
+        //
+        // var stdout = std.Io.File.stdout().writer(io, &.{});
+        // try stdout.interface.print("database page size: {}\n", .{page_size});
     }
 }

--- a/dockerfiles/zig-0.16.Dockerfile
+++ b/dockerfiles/zig-0.16.Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM debian:trixie
+
+# procps: shell / background-jobs
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        curl \
+        xz-utils \
+        procps \
+    && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download and install Zig
+RUN curl -O https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz \
+    && tar -xf zig-x86_64-linux-0.16.0.tar.xz \
+    && mv zig-x86_64-linux-0.16.0 /usr/local/zig \
+    && rm zig-x86_64-linux-0.16.0.tar.xz
+
+# Add Zig to PATH
+ENV PATH="/usr/local/zig:${PATH}"
+
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="build.zig,build.zig.zon"
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# This runs zig build
+RUN .codecrafters/compile.sh
+
+# Cache build directory
+RUN mkdir -p /app-cached
+RUN mv /app/.zig-cache /app-cached/.zig-cache || true

--- a/solutions/zig/01-dr6/code/README.md
+++ b/solutions/zig/01-dr6/code/README.md
@@ -29,7 +29,7 @@ Time to move on to the next stage!
 
 Note: This section is for stages 2 and beyond.
 
-1. Ensure you have `zig (0.15)` installed locally
+1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.zig`.
 1. Commit your changes and run `git push origin master` to submit your solution

--- a/solutions/zig/01-dr6/code/build.zig.zon
+++ b/solutions/zig/01-dr6/code/build.zig.zon
@@ -9,7 +9,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/solutions/zig/01-dr6/code/codecrafters.yml
+++ b/solutions/zig/01-dr6/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Zig version used to run your code
 # on Codecrafters.
 #
-# Available versions: zig-0.15.2
-buildpack: zig-0.15.2
+# Available versions: zig-0.16
+buildpack: zig-0.16

--- a/solutions/zig/01-dr6/code/src/main.zig
+++ b/solutions/zig/01-dr6/code/src/main.zig
@@ -1,18 +1,13 @@
 const std = @import("std");
-var stdout_buffer: [1024]u8 = undefined;
-var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-const stdout = &stdout_writer.interface;
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    var stderr = std.Io.File.stderr().writer(io, &.{});
 
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+    const args = try std.process.Args.toSlice(init.minimal.args, init.arena.allocator());
 
     if (args.len < 3) {
-        std.debug.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
+        try stderr.interface.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
         std.process.exit(1);
     }
 
@@ -20,14 +15,15 @@ pub fn main() !void {
     const command: []const u8 = args[2];
 
     if (std.mem.eql(u8, command, ".dbinfo")) {
-        var file = try std.fs.cwd().openFile(database_file_path, .{});
-        defer file.close();
+        var file = try std.Io.Dir.cwd().openFile(io, database_file_path, .{});
+        defer file.close(io);
 
-        var buf: [2]u8 = undefined;
-        _ = try file.seekTo(16);
-        _ = try file.read(&buf);
-        const page_size = std.mem.readInt(u16, &buf, .big);
-        try stdout.print("database page size: {}\n", .{page_size});
-        try stdout.flush();
+        var reader_buf: [4096]u8 = undefined;
+        var reader = file.reader(io, &reader_buf);
+        try reader.seekTo(16);
+        const page_size = std.mem.readInt(u16, try reader.interface.takeArray(2), .big);
+
+        var stdout = std.Io.File.stdout().writer(io, &.{});
+        try stdout.interface.print("database page size: {}\n", .{page_size});
     }
 }

--- a/solutions/zig/01-dr6/diff/src/main.zig.diff
+++ b/solutions/zig/01-dr6/diff/src/main.zig.diff
@@ -1,19 +1,14 @@
-@@ -1,37 +1,33 @@
+@@ -1,34 +1,29 @@
  const std = @import("std");
- var stdout_buffer: [1024]u8 = undefined;
- var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
- const stdout = &stdout_writer.interface;
 
- pub fn main() !void {
-     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-     defer _ = gpa.deinit();
-     const allocator = gpa.allocator();
+ pub fn main(init: std.process.Init) !void {
+     const io = init.io;
+     var stderr = std.Io.File.stderr().writer(io, &.{});
 
-     const args = try std.process.argsAlloc(allocator);
-     defer std.process.argsFree(allocator, args);
+     const args = try std.process.Args.toSlice(init.minimal.args, init.arena.allocator());
 
      if (args.len < 3) {
-         std.debug.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
+         try stderr.interface.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
          std.process.exit(1);
      }
 
@@ -21,24 +16,26 @@
      const command: []const u8 = args[2];
 
      if (std.mem.eql(u8, command, ".dbinfo")) {
-         var file = try std.fs.cwd().openFile(database_file_path, .{});
-         defer file.close();
+         var file = try std.Io.Dir.cwd().openFile(io, database_file_path, .{});
+         defer file.close(io);
 
 -        // You can use print statements as follows for debugging, they'll be visible when running tests.
--        std.debug.print("Logs from your program will appear here!\n", .{});
--
+-        try stderr.interface.print("Logs from your program will appear here!\n", .{});
++        var reader_buf: [4096]u8 = undefined;
++        var reader = file.reader(io, &reader_buf);
++        try reader.seekTo(16);
++        const page_size = std.mem.readInt(u16, try reader.interface.takeArray(2), .big);
+
 -        // TODO: Uncomment the code below to pass the first stage
--        // var buf: [2]u8 = undefined;
--        // _ = try file.seekTo(16);
--        // _ = try file.read(&buf);
--        // const page_size = std.mem.readInt(u16, &buf, .big);
--        // try stdout.print("database page size: {}\n", .{page_size});
--        // try stdout.flush();
-+        var buf: [2]u8 = undefined;
-+        _ = try file.seekTo(16);
-+        _ = try file.read(&buf);
-+        const page_size = std.mem.readInt(u16, &buf, .big);
-+        try stdout.print("database page size: {}\n", .{page_size});
-+        try stdout.flush();
+-        //
+-        // var reader_buf: [4096]u8 = undefined;
+-        // var reader = file.reader(io, &reader_buf);
+-        // try reader.seekTo(16);
+-        // const page_size = std.mem.readInt(u16, try reader.interface.takeArray(2), .big);
+-        //
+-        // var stdout = std.Io.File.stdout().writer(io, &.{});
+-        // try stdout.interface.print("database page size: {}\n", .{page_size});
++        var stdout = std.Io.File.stdout().writer(io, &.{});
++        try stdout.interface.print("database page size: {}\n", .{page_size});
      }
  }

--- a/starter_templates/zig/code/build.zig.zon
+++ b/starter_templates/zig/code/build.zig.zon
@@ -9,7 +9,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/starter_templates/zig/code/src/main.zig
+++ b/starter_templates/zig/code/src/main.zig
@@ -1,18 +1,13 @@
 const std = @import("std");
-var stdout_buffer: [1024]u8 = undefined;
-var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
-const stdout = &stdout_writer.interface;
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    var stderr = std.Io.File.stderr().writer(io, &.{});
 
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+    const args = try std.process.Args.toSlice(init.minimal.args, init.arena.allocator());
 
     if (args.len < 3) {
-        std.debug.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
+        try stderr.interface.print("Usage: {s} <database_file_path> <command>\n", .{args[0]});
         std.process.exit(1);
     }
 
@@ -20,18 +15,20 @@ pub fn main() !void {
     const command: []const u8 = args[2];
 
     if (std.mem.eql(u8, command, ".dbinfo")) {
-        var file = try std.fs.cwd().openFile(database_file_path, .{});
-        defer file.close();
+        var file = try std.Io.Dir.cwd().openFile(io, database_file_path, .{});
+        defer file.close(io);
 
         // You can use print statements as follows for debugging, they'll be visible when running tests.
-        std.debug.print("Logs from your program will appear here!\n", .{});
+        try stderr.interface.print("Logs from your program will appear here!\n", .{});
 
         // TODO: Uncomment the code below to pass the first stage
-        // var buf: [2]u8 = undefined;
-        // _ = try file.seekTo(16);
-        // _ = try file.read(&buf);
-        // const page_size = std.mem.readInt(u16, &buf, .big);
-        // try stdout.print("database page size: {}\n", .{page_size});
-        // try stdout.flush();
+        //
+        // var reader_buf: [4096]u8 = undefined;
+        // var reader = file.reader(io, &reader_buf);
+        // try reader.seekTo(16);
+        // const page_size = std.mem.readInt(u16, try reader.interface.takeArray(2), .big);
+        //
+        // var stdout = std.Io.File.stdout().writer(io, &.{});
+        // try stdout.interface.print("database page size: {}\n", .{page_size});
     }
 }

--- a/starter_templates/zig/config.yml
+++ b/starter_templates/zig/config.yml
@@ -1,3 +1,3 @@
 attributes:
-  required_executable: zig (0.15)
+  required_executable: zig (0.16)
   user_editable_file: src/main.zig


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it bumps the Zig toolchain and updates entrypoint/IO APIs, which can affect compilation and runtime behavior in the Zig starter/solution environments.
> 
> **Overview**
> Upgrades the Zig track from **0.15 to 0.16** across templates, compiled starters, and example solutions (README instructions, `codecrafters.yml` buildpack, `build.zig.zon` minimum version, and `config.yml` requirements).
> 
> Updates Zig `main.zig` scaffolding to the Zig 0.16 `std.process.Init` entrypoint and new `std.Io`-based file/stdio/args handling (including switching usage/debug output to `stderr`), and adds a new `dockerfiles/zig-0.16.Dockerfile` to build/run with Zig 0.16.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d327f046556c59223e641dc9d49231d73691c99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->