### PR TITLE
CC-2266: Add PHP starter for SQLite

### DIFF
--- a/compiled_starters/php/.codecrafters/compile.sh
+++ b/compiled_starters/php/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+# (This file is empty since PHP programs don't use a compile step)

--- a/compiled_starters/php/.codecrafters/run.sh
+++ b/compiled_starters/php/.codecrafters/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/compiled_starters/php/.gitattributes
+++ b/compiled_starters/php/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/compiled_starters/php/.gitignore
+++ b/compiled_starters/php/.gitignore
@@ -1,0 +1,2 @@
+# Database files used for testing
+*.db

--- a/compiled_starters/php/README.md
+++ b/compiled_starters/php/README.md
@@ -1,0 +1,76 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/sqlite.png)
+
+This is a starting point for PHP solutions to the
+["Build Your Own SQLite" Challenge](https://codecrafters.io/challenges/sqlite).
+
+In this challenge, you'll build a barebones SQLite implementation that supports
+basic SQL queries like `SELECT`. Along the way we'll learn about
+[SQLite's file format](https://www.sqlite.org/fileformat.html), how indexed data
+is
+[stored in B-trees](https://jvns.ca/blog/2014/10/02/how-does-sqlite-work-part-2-btrees/)
+and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your SQLite implementation is in `app/main.php`. Study and
+uncomment the relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+Time to move on to the next stage!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `php (8.5)` installed locally
+1. Run `./your_program.sh` to run your program, which is implemented in
+   `app/main.php`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.
+
+# Sample Databases
+
+To make it easy to test queries locally, we've added a sample database in the
+root of this repository: `sample.db`.
+
+This contains two tables: `apples` & `oranges`. You can use this to test your
+implementation for the first 6 stages.
+
+You can explore this database by running queries against it like this:
+
+```sh
+$ sqlite3 sample.db "select id, name from apples"
+1|Granny Smith
+2|Fuji
+3|Honeycrisp
+4|Golden Delicious
+```
+
+There are two other databases that you can use:
+
+1. `superheroes.db`:
+   - This is a small version of the test database used in the table-scan stage.
+   - It contains one table: `superheroes`.
+   - It is ~1MB in size.
+1. `companies.db`:
+   - This is a small version of the test database used in the index-scan stage.
+   - It contains one table: `companies`, and one index: `idx_companies_country`
+   - It is ~7MB in size.
+
+These aren't included in the repository because they're large in size. You can
+download them by running this script:
+
+```sh
+./download_sample_databases.sh
+```
+
+If the script doesn't work for some reason, you can download the databases
+directly from
+[codecrafters-io/sample-sqlite-databases](https://github.com/codecrafters-io/sample-sqlite-databases).

--- a/compiled_starters/php/app/main.php
+++ b/compiled_starters/php/app/main.php
@@ -1,0 +1,30 @@
+<?php
+error_reporting(E_ALL);
+
+if ($argc < 3) {
+    fwrite(STDERR, "Usage: {$argv[0]} <database_file_path> <command>\n");
+    exit(1);
+}
+
+$database_file_path = $argv[1];
+$command = $argv[2];
+
+if ($command === '.dbinfo') {
+    $database_file = fopen($database_file_path, 'rb');
+    if ($database_file === false) {
+        fwrite(STDERR, "Failed to open database file\n");
+        exit(1);
+    }
+
+    // You can use print statements as follows for debugging, they'll be visible when running tests.
+    fwrite(STDERR, "Logs from your program will appear here!\n");
+
+    // TODO: Uncomment the code below to pass the first stage
+    // fseek($database_file, 16); // Skip the first 16 bytes of the header
+    // $page_size = unpack('n', fread($database_file, 2))[1];
+    // fwrite(STDOUT, "database page size: {$page_size}\n");
+
+    fclose($database_file);
+} else {
+    fwrite(STDOUT, "Invalid command: {$command}\n");
+}

--- a/compiled_starters/php/codecrafters.yml
+++ b/compiled_starters/php/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the PHP version used to run your code
+# on Codecrafters.
+#
+# Available versions: php-8.5
+buildpack: php-8.5

--- a/compiled_starters/php/download_sample_databases.sh
+++ b/compiled_starters/php/download_sample_databases.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "Downloading superheroes.db: ~1MB (used in stage 7)"
+curl -Lo superheroes.db https://raw.githubusercontent.com/codecrafters-io/sample-sqlite-databases/master/superheroes.db
+
+echo "Downloading companies.db: ~7MB (used in stage 8)"
+curl -Lo companies.db https://raw.githubusercontent.com/codecrafters-io/sample-sqlite-databases/master/companies.db
+
+echo "Sample databases downloaded."

--- a/compiled_starters/php/your_program.sh
+++ b/compiled_starters/php/your_program.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -40,6 +40,7 @@ languages:
   - slug: "java"
   - slug: "javascript"
   - slug: "kotlin"
+  - slug: "php"
   - slug: "python"
   - slug: "ruby"
   - slug: "rust"

--- a/dockerfiles/php-8.5.Dockerfile
+++ b/dockerfiles/php-8.5.Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM php:8.5-cli-alpine3.22
+
+# For ext-sockets installation
+RUN apk add linux-headers=~6.14.2-r0 --no-cache
+
+RUN docker-php-ext-install pcntl sockets

--- a/solutions/php/01-dr6/code/.codecrafters/compile.sh
+++ b/solutions/php/01-dr6/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+# (This file is empty since PHP programs don't use a compile step)

--- a/solutions/php/01-dr6/code/.codecrafters/run.sh
+++ b/solutions/php/01-dr6/code/.codecrafters/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/solutions/php/01-dr6/code/.gitattributes
+++ b/solutions/php/01-dr6/code/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/solutions/php/01-dr6/code/.gitignore
+++ b/solutions/php/01-dr6/code/.gitignore
@@ -1,0 +1,2 @@
+# Database files used for testing
+*.db

--- a/solutions/php/01-dr6/code/README.md
+++ b/solutions/php/01-dr6/code/README.md
@@ -1,0 +1,76 @@
+![progress-banner](https://codecrafters.io/landing/images/default_progress_banners/sqlite.png)
+
+This is a starting point for PHP solutions to the
+["Build Your Own SQLite" Challenge](https://codecrafters.io/challenges/sqlite).
+
+In this challenge, you'll build a barebones SQLite implementation that supports
+basic SQL queries like `SELECT`. Along the way we'll learn about
+[SQLite's file format](https://www.sqlite.org/fileformat.html), how indexed data
+is
+[stored in B-trees](https://jvns.ca/blog/2014/10/02/how-does-sqlite-work-part-2-btrees/)
+and more.
+
+**Note**: If you're viewing this repo on GitHub, head over to
+[codecrafters.io](https://codecrafters.io) to try the challenge.
+
+# Passing the first stage
+
+The entry point for your SQLite implementation is in `app/main.php`. Study and
+uncomment the relevant code, and push your changes to pass the first stage:
+
+```sh
+git commit -am "pass 1st stage" # any msg
+git push origin master
+```
+
+Time to move on to the next stage!
+
+# Stage 2 & beyond
+
+Note: This section is for stages 2 and beyond.
+
+1. Ensure you have `php (8.5)` installed locally
+1. Run `./your_program.sh` to run your program, which is implemented in
+   `app/main.php`.
+1. Commit your changes and run `git push origin master` to submit your solution
+   to CodeCrafters. Test output will be streamed to your terminal.
+
+# Sample Databases
+
+To make it easy to test queries locally, we've added a sample database in the
+root of this repository: `sample.db`.
+
+This contains two tables: `apples` & `oranges`. You can use this to test your
+implementation for the first 6 stages.
+
+You can explore this database by running queries against it like this:
+
+```sh
+$ sqlite3 sample.db "select id, name from apples"
+1|Granny Smith
+2|Fuji
+3|Honeycrisp
+4|Golden Delicious
+```
+
+There are two other databases that you can use:
+
+1. `superheroes.db`:
+   - This is a small version of the test database used in the table-scan stage.
+   - It contains one table: `superheroes`.
+   - It is ~1MB in size.
+1. `companies.db`:
+   - This is a small version of the test database used in the index-scan stage.
+   - It contains one table: `companies`, and one index: `idx_companies_country`
+   - It is ~7MB in size.
+
+These aren't included in the repository because they're large in size. You can
+download them by running this script:
+
+```sh
+./download_sample_databases.sh
+```
+
+If the script doesn't work for some reason, you can download the databases
+directly from
+[codecrafters-io/sample-sqlite-databases](https://github.com/codecrafters-io/sample-sqlite-databases).

--- a/solutions/php/01-dr6/code/app/main.php
+++ b/solutions/php/01-dr6/code/app/main.php
@@ -1,0 +1,26 @@
+<?php
+error_reporting(E_ALL);
+
+if ($argc < 3) {
+    fwrite(STDERR, "Usage: {$argv[0]} <database_file_path> <command>\n");
+    exit(1);
+}
+
+$database_file_path = $argv[1];
+$command = $argv[2];
+
+if ($command === '.dbinfo') {
+    $database_file = fopen($database_file_path, 'rb');
+    if ($database_file === false) {
+        fwrite(STDERR, "Failed to open database file\n");
+        exit(1);
+    }
+
+    fseek($database_file, 16); // Skip the first 16 bytes of the header
+    $page_size = unpack('n', fread($database_file, 2))[1];
+    fwrite(STDOUT, "database page size: {$page_size}\n");
+
+    fclose($database_file);
+} else {
+    fwrite(STDOUT, "Invalid command: {$command}\n");
+}

--- a/solutions/php/01-dr6/code/codecrafters.yml
+++ b/solutions/php/01-dr6/code/codecrafters.yml
@@ -1,0 +1,11 @@
+# Set this to true if you want debug logs.
+#
+# These can be VERY verbose, so we suggest turning them off
+# unless you really need them.
+debug: false
+
+# Use this to change the PHP version used to run your code
+# on Codecrafters.
+#
+# Available versions: php-8.5
+buildpack: php-8.5

--- a/solutions/php/01-dr6/code/download_sample_databases.sh
+++ b/solutions/php/01-dr6/code/download_sample_databases.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "Downloading superheroes.db: ~1MB (used in stage 7)"
+curl -Lo superheroes.db https://raw.githubusercontent.com/codecrafters-io/sample-sqlite-databases/master/superheroes.db
+
+echo "Downloading companies.db: ~7MB (used in stage 8)"
+curl -Lo companies.db https://raw.githubusercontent.com/codecrafters-io/sample-sqlite-databases/master/companies.db
+
+echo "Sample databases downloaded."

--- a/solutions/php/01-dr6/code/your_program.sh
+++ b/solutions/php/01-dr6/code/your_program.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# Use this script to run your program LOCALLY.
+#
+# Note: Changing this script WILL NOT affect how CodeCrafters runs your program.
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit early if any commands fail
+
+# Copied from .codecrafters/run.sh
+#
+# - Edit this to change how your program runs locally
+# - Edit .codecrafters/run.sh to change how your program runs remotely
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/solutions/php/01-dr6/diff/app/main.php.diff
+++ b/solutions/php/01-dr6/diff/app/main.php.diff
@@ -1,0 +1,34 @@
+@@ -1,30 +1,26 @@
+ <?php
+ error_reporting(E_ALL);
+
+ if ($argc < 3) {
+     fwrite(STDERR, "Usage: {$argv[0]} <database_file_path> <command>\n");
+     exit(1);
+ }
+
+ $database_file_path = $argv[1];
+ $command = $argv[2];
+
+ if ($command === '.dbinfo') {
+     $database_file = fopen($database_file_path, 'rb');
+     if ($database_file === false) {
+         fwrite(STDERR, "Failed to open database file\n");
+         exit(1);
+     }
+
+-    // You can use print statements as follows for debugging, they'll be visible when running tests.
+-    fwrite(STDERR, "Logs from your program will appear here!\n");
+-
+-    // TODO: Uncomment the code below to pass the first stage
+-    // fseek($database_file, 16); // Skip the first 16 bytes of the header
+-    // $page_size = unpack('n', fread($database_file, 2))[1];
+-    // fwrite(STDOUT, "database page size: {$page_size}\n");
++    fseek($database_file, 16); // Skip the first 16 bytes of the header
++    $page_size = unpack('n', fread($database_file, 2))[1];
++    fwrite(STDOUT, "database page size: {$page_size}\n");
+
+     fclose($database_file);
+ } else {
+     fwrite(STDOUT, "Invalid command: {$command}\n");
+ }

--- a/starter_templates/php/code/.codecrafters/compile.sh
+++ b/starter_templates/php/code/.codecrafters/compile.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# This script is used to compile your program on CodeCrafters
+#
+# This runs before .codecrafters/run.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+# (This file is empty since PHP programs don't use a compile step)

--- a/starter_templates/php/code/.codecrafters/run.sh
+++ b/starter_templates/php/code/.codecrafters/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+#
+# This script is used to run your program on CodeCrafters
+#
+# This runs after .codecrafters/compile.sh
+#
+# Learn more: https://codecrafters.io/program-interface
+
+set -e # Exit on failure
+
+SCRIPT_DIR="$(dirname "$0")"
+exec php "$SCRIPT_DIR/app/main.php" "$@"

--- a/starter_templates/php/code/app/main.php
+++ b/starter_templates/php/code/app/main.php
@@ -1,0 +1,30 @@
+<?php
+error_reporting(E_ALL);
+
+if ($argc < 3) {
+    fwrite(STDERR, "Usage: {$argv[0]} <database_file_path> <command>\n");
+    exit(1);
+}
+
+$database_file_path = $argv[1];
+$command = $argv[2];
+
+if ($command === '.dbinfo') {
+    $database_file = fopen($database_file_path, 'rb');
+    if ($database_file === false) {
+        fwrite(STDERR, "Failed to open database file\n");
+        exit(1);
+    }
+
+    // You can use print statements as follows for debugging, they'll be visible when running tests.
+    fwrite(STDERR, "Logs from your program will appear here!\n");
+
+    // TODO: Uncomment the code below to pass the first stage
+    // fseek($database_file, 16); // Skip the first 16 bytes of the header
+    // $page_size = unpack('n', fread($database_file, 2))[1];
+    // fwrite(STDOUT, "database page size: {$page_size}\n");
+
+    fclose($database_file);
+} else {
+    fwrite(STDOUT, "Invalid command: {$command}\n");
+}

--- a/starter_templates/php/config.yml
+++ b/starter_templates/php/config.yml
@@ -1,0 +1,3 @@
+attributes:
+  required_executable: "php (8.5)"
+  user_editable_file: "app/main.php"


### PR DESCRIPTION
- Added PHP to the list of supported languages in course-definition.yml.
- Created starter files for PHP solutions, including:
  - .gitattributes and .gitignore for handling text files and ignoring database files.
  - codecrafters.yml for configuration settings.
  - download_sample_databases.sh for downloading necessary sample databases.
  - README.md with instructions for the SQLite challenge.
  - your_program.sh for local execution of the program.
  - compile.sh and run.sh scripts for CodeCrafters integration.
  - app/main.php as the main entry point for the SQLite implementation.
- Added Dockerfile for PHP 8.5 environment setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive scaffolding, but it introduces a new PHP build/runtime path (new Dockerfile and CodeCrafters run scripts) that could affect CI/build infrastructure if misconfigured.
> 
> **Overview**
> Adds **PHP support** to the SQLite course by registering `php` in `course-definition.yml` and introducing full PHP starter scaffolding (`starter_templates/php` and `compiled_starters/php`) with CodeCrafters `compile.sh`/`run.sh`, local `your_program.sh`, config, README, and a minimal `app/main.php` entrypoint.
> 
> Introduces a PHP 8.5 execution environment via `dockerfiles/php-8.5.Dockerfile` (installs `pcntl`/`sockets`) and adds a reference solution for stage `dr6` under `solutions/php/01-dr6` that implements `.dbinfo` page-size output, along with a stored diff for that stage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e087d4cd7aee8e54596210d3e42c35e3731120c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->