### PR TITLE
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

### DIFF
--- a/compiled_starters/c/README.md
+++ b/compiled_starters/c/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.c`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/clojure/README.md
+++ b/compiled_starters/clojure/README.md
@@ -33,8 +33,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `clj` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/sqlite/core.clj`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/cpp/README.md
+++ b/compiled_starters/cpp/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.cpp`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/csharp/README.md
+++ b/compiled_starters/csharp/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dotnet (9.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/Program.cs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/elixir/README.md
+++ b/compiled_starters/elixir/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `lib/main.ex`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/gleam/README.md
+++ b/compiled_starters/gleam/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gleam (1.14.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.gleam`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.go`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/java/README.md
+++ b/compiled_starters/java/README.md
@@ -33,8 +33,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mvn` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main/java/Main.java`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/javascript/README.md
+++ b/compiled_starters/javascript/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.js`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/kotlin/README.md
+++ b/compiled_starters/kotlin/README.md
@@ -33,8 +33,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gradle (9.4.1)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/src/main/kotlin/App.kt`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/php/README.md
+++ b/compiled_starters/php/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `php (8.5)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.php`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `uv` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.py`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/ruby/README.md
+++ b/compiled_starters/ruby/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.rb`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -33,8 +33,8 @@ Note: This section is for stages 2 and beyond.
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/swift/README.md
+++ b/compiled_starters/swift/README.md
@@ -33,8 +33,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `swift (5.7)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `Sources/swift-sqlite-challenge/Main.swift`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `bun (1.3)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.ts`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.zig`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/c/01-dr6/code/README.md
+++ b/solutions/c/01-dr6/code/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.c`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/clojure/01-dr6/code/README.md
+++ b/solutions/clojure/01-dr6/code/README.md
@@ -33,8 +33,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `clj` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/sqlite/core.clj`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/cpp/01-dr6/code/README.md
+++ b/solutions/cpp/01-dr6/code/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `cmake` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.cpp`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/csharp/01-dr6/code/README.md
+++ b/solutions/csharp/01-dr6/code/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `dotnet (9.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/Program.cs`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/elixir/01-dr6/code/README.md
+++ b/solutions/elixir/01-dr6/code/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mix` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `lib/main.ex`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/gleam/01-dr6/code/README.md
+++ b/solutions/gleam/01-dr6/code/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gleam (1.14.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.gleam`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/go/01-dr6/code/README.md
+++ b/solutions/go/01-dr6/code/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `go (1.26)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.go`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/java/01-dr6/code/README.md
+++ b/solutions/java/01-dr6/code/README.md
@@ -33,8 +33,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `mvn` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main/java/Main.java`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/javascript/01-dr6/code/README.md
+++ b/solutions/javascript/01-dr6/code/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `node (25)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.js`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/kotlin/01-dr6/code/README.md
+++ b/solutions/kotlin/01-dr6/code/README.md
@@ -33,8 +33,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `gradle (9.4.1)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/src/main/kotlin/App.kt`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/php/01-dr6/code/README.md
+++ b/solutions/php/01-dr6/code/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `php (8.5)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.php`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/python/01-dr6/code/README.md
+++ b/solutions/python/01-dr6/code/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `uv` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.py`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/ruby/01-dr6/code/README.md
+++ b/solutions/ruby/01-dr6/code/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `ruby (4.0)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.rb`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/rust/01-dr6/code/README.md
+++ b/solutions/rust/01-dr6/code/README.md
@@ -33,8 +33,8 @@ Note: This section is for stages 2 and beyond.
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.rs`. This command compiles your Rust project, so it might be slow
    the first time you run it. Subsequent runs will be fast.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/swift/01-dr6/code/README.md
+++ b/solutions/swift/01-dr6/code/README.md
@@ -33,8 +33,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `swift (5.7)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `Sources/swift-sqlite-challenge/Main.swift`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/typescript/01-dr6/code/README.md
+++ b/solutions/typescript/01-dr6/code/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `bun (1.3)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `app/main.ts`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/solutions/zig/01-dr6/code/README.md
+++ b/solutions/zig/01-dr6/code/README.md
@@ -32,8 +32,8 @@ Note: This section is for stages 2 and beyond.
 1. Ensure you have `zig (0.16)` installed locally
 1. Run `./your_program.sh` to run your program, which is implemented in
    `src/main.zig`.
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test
+   output will be streamed to your terminal.
 
 # Sample Databases
 

--- a/starter_templates/all/code/README.md
+++ b/starter_templates/all/code/README.md
@@ -32,8 +32,7 @@ Note: This section is for stages 2 and beyond.
    `{{ user_editable_file }}`.{{# language_is_rust }} This command compiles your
    Rust project, so it might be slow the first time you run it. Subsequent runs
    will be fast.{{/ language_is_rust}}
-1. Commit your changes and run `git push origin master` to submit your solution
-   to CodeCrafters. Test output will be streamed to your terminal.
+1. Run `codecrafters submit` to submit your solution to CodeCrafters. Test output will be streamed to your terminal.
 
 # Sample Databases
 


### PR DESCRIPTION
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that change the recommended submission command; no runtime or build logic is modified.
> 
> **Overview**
> Updates SQLite challenge starter/solution READMEs (and the shared `starter_templates/all/code/README.md`) to replace the Stage 2+ submission guidance from `git push origin master` to `codecrafters submit`, keeping the rest of the workflow intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30e55f8eb59ea2363a03c2a03edb3b9f226c27db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->