### PR TITLE
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

### DIFF
--- a/compiled_starters/c/README.md
+++ b/compiled_starters/c/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/main.c`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/clojure/README.md
+++ b/compiled_starters/clojure/README.md
@@ -16,12 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/sqlite/core.clj`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/cpp/README.md
+++ b/compiled_starters/cpp/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/main.cpp`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/csharp/README.md
+++ b/compiled_starters/csharp/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/Program.cs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/elixir/README.md
+++ b/compiled_starters/elixir/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `lib/main.ex`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/gleam/README.md
+++ b/compiled_starters/gleam/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/main.gleam`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/go/README.md
+++ b/compiled_starters/go/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `app/main.go`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/java/README.md
+++ b/compiled_starters/java/README.md
@@ -16,12 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/main/java/Main.java`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/javascript/README.md
+++ b/compiled_starters/javascript/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `app/main.js`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/kotlin/README.md
+++ b/compiled_starters/kotlin/README.md
@@ -16,12 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and then
+run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/php/README.md
+++ b/compiled_starters/php/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `app/main.php`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/python/README.md
+++ b/compiled_starters/python/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `app/main.py`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/ruby/README.md
+++ b/compiled_starters/ruby/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `app/main.rb`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/rust/README.md
+++ b/compiled_starters/rust/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/main.rs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/swift/README.md
+++ b/compiled_starters/swift/README.md
@@ -17,11 +17,10 @@ and more.
 
 The entry point for your SQLite implementation is in
 `Sources/swift-sqlite-challenge/Main.swift`. Study and uncomment the relevant
-code, and push your changes to pass the first stage:
+code, and then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/typescript/README.md
+++ b/compiled_starters/typescript/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `app/main.ts`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/compiled_starters/zig/README.md
+++ b/compiled_starters/zig/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/main.zig`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/c/01-dr6/code/README.md
+++ b/solutions/c/01-dr6/code/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/main.c`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/clojure/01-dr6/code/README.md
+++ b/solutions/clojure/01-dr6/code/README.md
@@ -16,12 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/sqlite/core.clj`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/cpp/01-dr6/code/README.md
+++ b/solutions/cpp/01-dr6/code/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/main.cpp`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/csharp/01-dr6/code/README.md
+++ b/solutions/csharp/01-dr6/code/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/Program.cs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/elixir/01-dr6/code/README.md
+++ b/solutions/elixir/01-dr6/code/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `lib/main.ex`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/gleam/01-dr6/code/README.md
+++ b/solutions/gleam/01-dr6/code/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/main.gleam`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/go/01-dr6/code/README.md
+++ b/solutions/go/01-dr6/code/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `app/main.go`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/java/01-dr6/code/README.md
+++ b/solutions/java/01-dr6/code/README.md
@@ -16,12 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/main/java/Main.java`.
-Study and uncomment the relevant code, and push your changes to pass the first
-stage:
+Study and uncomment the relevant code, and then run the command below to execute
+the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/javascript/01-dr6/code/README.md
+++ b/solutions/javascript/01-dr6/code/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `app/main.js`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/kotlin/01-dr6/code/README.md
+++ b/solutions/kotlin/01-dr6/code/README.md
@@ -16,12 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in
-`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and push
-your changes to pass the first stage:
+`app/src/main/kotlin/App.kt`. Study and uncomment the relevant code, and then
+run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/php/01-dr6/code/README.md
+++ b/solutions/php/01-dr6/code/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `app/main.php`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/python/01-dr6/code/README.md
+++ b/solutions/python/01-dr6/code/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `app/main.py`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/ruby/01-dr6/code/README.md
+++ b/solutions/ruby/01-dr6/code/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `app/main.rb`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/rust/01-dr6/code/README.md
+++ b/solutions/rust/01-dr6/code/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/main.rs`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/swift/01-dr6/code/README.md
+++ b/solutions/swift/01-dr6/code/README.md
@@ -17,11 +17,10 @@ and more.
 
 The entry point for your SQLite implementation is in
 `Sources/swift-sqlite-challenge/Main.swift`. Study and uncomment the relevant
-code, and push your changes to pass the first stage:
+code, and then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/typescript/01-dr6/code/README.md
+++ b/solutions/typescript/01-dr6/code/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `app/main.ts`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/solutions/zig/01-dr6/code/README.md
+++ b/solutions/zig/01-dr6/code/README.md
@@ -16,11 +16,11 @@ and more.
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `src/main.zig`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
+uncomment the relevant code, and then run the command below to execute the tests
+on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!

--- a/starter_templates/all/code/README.md
+++ b/starter_templates/all/code/README.md
@@ -14,11 +14,10 @@ is [stored in B-trees](https://jvns.ca/blog/2014/10/02/how-does-sqlite-work-part
 # Passing the first stage
 
 The entry point for your SQLite implementation is in `{{ user_editable_file }}`. Study and uncomment the relevant code, and
-push your changes to pass the first stage:
+then run the command below to execute the tests on our servers:
 
 ```sh
-git commit -am "pass 1st stage" # any msg
-git push origin master
+codecrafters submit
 ```
 
 Time to move on to the next stage!


### PR DESCRIPTION
https://linear.app/codecrafters/issue/CC-2159/replace-git-commands-in-readmes-as-cc-submit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates README guidance; no runtime or build logic is modified.
> 
> **Overview**
> Updates SQLite challenge READMEs (starter templates, compiled starters, and solution snapshots) to **replace git-based submission instructions** with `codecrafters submit`.
> 
> Also tweaks the first-stage wording to direct users to run the submission command to execute tests on CodeCrafters’ servers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 746cfd34cba26bda8b587896ca412015c112bb54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->