### PR TITLE
CC-2274: Upgrade Gleam to v0.16

### DIFF
--- a/compiled_starters/gleam/.codecrafters/compile.sh
+++ b/compiled_starters/gleam/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/compiled_starters/gleam/.codecrafters/run.sh
+++ b/compiled_starters/gleam/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/compiled_starters/gleam/.gitignore
+++ b/compiled_starters/gleam/.gitignore
@@ -5,3 +5,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/compiled_starters/gleam/codecrafters.yml
+++ b/compiled_starters/gleam/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/compiled_starters/gleam/gleam.toml
+++ b/compiled_starters/gleam/gleam.toml
@@ -1,13 +1,14 @@
-name = "codecrafters_sqlite"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
+gleam_stdlib = "~> 1.0"
 argv = ">= 1.0.2 and < 2.0.0"
 file_streams = ">= 0.4.2 and < 1.0.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/compiled_starters/gleam/manifest.toml
+++ b/compiled_starters/gleam/manifest.toml
@@ -2,14 +2,22 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
-  { name = "file_streams", version = "0.4.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "file_streams", source = "hex", outer_checksum = "86775D2F36B74C54C64CA9080ACA9B9CF4655759E8D3E87E1A2EA9B0FA8D0804" },
-  { name = "gleam_stdlib", version = "0.37.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5398BD6C2ABA17338F676F42F404B9B7BABE1C8DC7380031ACB05BBE1BCF3742" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "file_streams", version = "0.6.3", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "file_streams", source = "hex", outer_checksum = "EC0DA36A4A5A79EB1281DD21247F062AD64D171D53C06ED4B4F520B0BC77F710" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
 argv = { version = ">= 1.0.2 and < 2.0.0" }
 file_streams = { version = ">= 0.4.2 and < 1.0.0" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_stdlib = { version = "~> 1.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/compiled_starters/gleam/src/main.gleam
+++ b/compiled_starters/gleam/src/main.gleam
@@ -1,6 +1,6 @@
 import argv
-import file_streams/read_stream
-import gleam/int.{to_string}
+import file_streams/file_stream
+import gleam/int
 import gleam/io
 
 pub fn main() {
@@ -12,14 +12,19 @@ pub fn main() {
   // TODO: Uncomment the code below to pass the first stage
   // case args {
   //   [database_file_path, ".dbinfo", ..] -> {
-  //     let assert Ok(rs) = read_stream.open(database_file_path)
-  //     // Skip the first 16 bytes
-  //     let assert Ok(_bytes) = read_stream.read_bytes_exact(rs, 16)
+  //     let assert Ok(stream) = file_stream.open_read(database_file_path)
+  //     // Skip the first 16 bytes of the header
+  //     let assert Ok(_skip) = file_stream.read_bytes_exact(stream, 16)
   //     // The next 2 bytes hold the page size in big-endian format
-  //     let assert Ok(page_size) = read_stream.read_uint16_be(rs)
+  //     let assert Ok(header) = file_stream.read_bytes_exact(stream, 2)
+  //     let page_size = case header {
+  //       <<hi, lo>> -> hi * 256 + lo
+  //       _ -> 0
+  //     }
+  //     let assert Ok(Nil) = file_stream.close(stream)
   //
   //     io.print("database page size: ")
-  //     io.println(to_string(page_size))
+  //     io.println(int.to_string(page_size))
   //   }
   //   _ -> {
   //     io.println("Unknown command")

--- a/compiled_starters/gleam/your_program.sh
+++ b/compiled_starters/gleam/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/dockerfiles/gleam-1.16.Dockerfile
+++ b/dockerfiles/gleam-1.16.Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7-labs
+FROM ghcr.io/gleam-lang/gleam:v1.16.0-erlang-alpine
+
+# Rebuild if gleam.toml or manifest.toml change
+ENV CODECRAFTERS_DEPENDENCY_FILE_PATHS="gleam.toml,manifest.toml"
+
+RUN apk add --no-cache \
+    build-base~=0.5
+
+WORKDIR /app
+
+# .git & README.md are unique per-repository. We ignore them on first copy to prevent cache misses
+COPY --exclude=.git --exclude=README.md . /app
+
+# Force deps to be downloaded
+RUN gleam build
+
+# Cache build directory
+RUN mkdir -p /app-cached
+RUN mv build /app-cached/build

--- a/solutions/gleam/01-dr6/code/.codecrafters/compile.sh
+++ b/solutions/gleam/01-dr6/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/solutions/gleam/01-dr6/code/.codecrafters/run.sh
+++ b/solutions/gleam/01-dr6/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/01-dr6/code/.gitignore
+++ b/solutions/gleam/01-dr6/code/.gitignore
@@ -5,3 +5,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/solutions/gleam/01-dr6/code/codecrafters.yml
+++ b/solutions/gleam/01-dr6/code/codecrafters.yml
@@ -7,5 +7,5 @@ debug: false
 # Use this to change the Gleam version used to run your code
 # on Codecrafters.
 #
-# Available versions: gleam-1.14
-buildpack: gleam-1.14
+# Available versions: gleam-1.16
+buildpack: gleam-1.16

--- a/solutions/gleam/01-dr6/code/gleam.toml
+++ b/solutions/gleam/01-dr6/code/gleam.toml
@@ -1,13 +1,14 @@
-name = "codecrafters_sqlite"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
+gleam_stdlib = "~> 1.0"
 argv = ">= 1.0.2 and < 2.0.0"
 file_streams = ">= 0.4.2 and < 1.0.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/solutions/gleam/01-dr6/code/manifest.toml
+++ b/solutions/gleam/01-dr6/code/manifest.toml
@@ -2,14 +2,22 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
-  { name = "file_streams", version = "0.4.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "file_streams", source = "hex", outer_checksum = "86775D2F36B74C54C64CA9080ACA9B9CF4655759E8D3E87E1A2EA9B0FA8D0804" },
-  { name = "gleam_stdlib", version = "0.37.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5398BD6C2ABA17338F676F42F404B9B7BABE1C8DC7380031ACB05BBE1BCF3742" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "file_streams", version = "0.6.3", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "file_streams", source = "hex", outer_checksum = "EC0DA36A4A5A79EB1281DD21247F062AD64D171D53C06ED4B4F520B0BC77F710" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
 argv = { version = ">= 1.0.2 and < 2.0.0" }
 file_streams = { version = ">= 0.4.2 and < 1.0.0" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_stdlib = { version = "~> 1.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/solutions/gleam/01-dr6/code/src/main.gleam
+++ b/solutions/gleam/01-dr6/code/src/main.gleam
@@ -1,6 +1,6 @@
 import argv
-import file_streams/read_stream
-import gleam/int.{to_string}
+import file_streams/file_stream
+import gleam/int
 import gleam/io
 
 pub fn main() {
@@ -8,14 +8,19 @@ pub fn main() {
 
   case args {
     [database_file_path, ".dbinfo", ..] -> {
-      let assert Ok(rs) = read_stream.open(database_file_path)
-      // Skip the first 16 bytes
-      let assert Ok(_bytes) = read_stream.read_bytes_exact(rs, 16)
+      let assert Ok(stream) = file_stream.open_read(database_file_path)
+      // Skip the first 16 bytes of the header
+      let assert Ok(_skip) = file_stream.read_bytes_exact(stream, 16)
       // The next 2 bytes hold the page size in big-endian format
-      let assert Ok(page_size) = read_stream.read_uint16_be(rs)
+      let assert Ok(header) = file_stream.read_bytes_exact(stream, 2)
+      let page_size = case header {
+        <<hi, lo>> -> hi * 256 + lo
+        _ -> 0
+      }
+      let assert Ok(Nil) = file_stream.close(stream)
 
       io.print("database page size: ")
-      io.println(to_string(page_size))
+      io.println(int.to_string(page_size))
     }
     _ -> {
       io.println("Unknown command")

--- a/solutions/gleam/01-dr6/code/your_program.sh
+++ b/solutions/gleam/01-dr6/code/your_program.sh
@@ -15,10 +15,11 @@ set -e # Exit early if any commands fail
 (
   cd "$(dirname "$0")" # Ensure compile steps are run within the repository directory
   gleam build
+  gleam run -m gleescript
 )
 
 # Copied from .codecrafters/run.sh
 #
 # - Edit this to change how your program runs locally
 # - Edit .codecrafters/run.sh to change how your program runs remotely
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/solutions/gleam/01-dr6/diff/src/main.gleam.diff
+++ b/solutions/gleam/01-dr6/diff/src/main.gleam.diff
@@ -1,7 +1,7 @@
-@@ -1,28 +1,24 @@
+@@ -1,33 +1,29 @@
  import argv
- import file_streams/read_stream
- import gleam/int.{to_string}
+ import file_streams/file_stream
+ import gleam/int
  import gleam/io
 
  pub fn main() {
@@ -13,14 +13,19 @@
 -  // TODO: Uncomment the code below to pass the first stage
 -  // case args {
 -  //   [database_file_path, ".dbinfo", ..] -> {
--  //     let assert Ok(rs) = read_stream.open(database_file_path)
--  //     // Skip the first 16 bytes
--  //     let assert Ok(_bytes) = read_stream.read_bytes_exact(rs, 16)
+-  //     let assert Ok(stream) = file_stream.open_read(database_file_path)
+-  //     // Skip the first 16 bytes of the header
+-  //     let assert Ok(_skip) = file_stream.read_bytes_exact(stream, 16)
 -  //     // The next 2 bytes hold the page size in big-endian format
--  //     let assert Ok(page_size) = read_stream.read_uint16_be(rs)
+-  //     let assert Ok(header) = file_stream.read_bytes_exact(stream, 2)
+-  //     let page_size = case header {
+-  //       <<hi, lo>> -> hi * 256 + lo
+-  //       _ -> 0
+-  //     }
+-  //     let assert Ok(Nil) = file_stream.close(stream)
 -  //
 -  //     io.print("database page size: ")
--  //     io.println(to_string(page_size))
+-  //     io.println(int.to_string(page_size))
 -  //   }
 -  //   _ -> {
 -  //     io.println("Unknown command")
@@ -28,14 +33,19 @@
 -  // }
 +  case args {
 +    [database_file_path, ".dbinfo", ..] -> {
-+      let assert Ok(rs) = read_stream.open(database_file_path)
-+      // Skip the first 16 bytes
-+      let assert Ok(_bytes) = read_stream.read_bytes_exact(rs, 16)
++      let assert Ok(stream) = file_stream.open_read(database_file_path)
++      // Skip the first 16 bytes of the header
++      let assert Ok(_skip) = file_stream.read_bytes_exact(stream, 16)
 +      // The next 2 bytes hold the page size in big-endian format
-+      let assert Ok(page_size) = read_stream.read_uint16_be(rs)
++      let assert Ok(header) = file_stream.read_bytes_exact(stream, 2)
++      let page_size = case header {
++        <<hi, lo>> -> hi * 256 + lo
++        _ -> 0
++      }
++      let assert Ok(Nil) = file_stream.close(stream)
 +
 +      io.print("database page size: ")
-+      io.println(to_string(page_size))
++      io.println(int.to_string(page_size))
 +    }
 +    _ -> {
 +      io.println("Unknown command")

--- a/starter_templates/gleam/code/.codecrafters/compile.sh
+++ b/starter_templates/gleam/code/.codecrafters/compile.sh
@@ -9,3 +9,4 @@
 set -e # Exit on failure
 
 gleam build
+gleam run -m gleescript

--- a/starter_templates/gleam/code/.codecrafters/run.sh
+++ b/starter_templates/gleam/code/.codecrafters/run.sh
@@ -8,4 +8,4 @@
 
 set -e # Exit on failure
 
-exec gleam run --no-print-progress --module main -- "$@"
+exec "$(dirname "$0")/main" "$@"

--- a/starter_templates/gleam/code/.gitignore
+++ b/starter_templates/gleam/code/.gitignore
@@ -2,3 +2,4 @@
 *.ez
 /build
 erl_crash.dump
+main

--- a/starter_templates/gleam/code/gleam.toml
+++ b/starter_templates/gleam/code/gleam.toml
@@ -1,13 +1,14 @@
-name = "codecrafters_sqlite"
+name = "main"
 version = "1.0.0"
 
 # For a full reference of all the available options, you can have a look at
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
+gleam_stdlib = "~> 1.0"
 argv = ">= 1.0.2 and < 2.0.0"
 file_streams = ">= 0.4.2 and < 1.0.0"
 
 [dev-dependencies]
+gleescript = ">= 1.4.0 and < 2.0.0"
 gleeunit = "~> 1.0"

--- a/starter_templates/gleam/code/manifest.toml
+++ b/starter_templates/gleam/code/manifest.toml
@@ -2,14 +2,22 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
-  { name = "file_streams", version = "0.4.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "file_streams", source = "hex", outer_checksum = "86775D2F36B74C54C64CA9080ACA9B9CF4655759E8D3E87E1A2EA9B0FA8D0804" },
-  { name = "gleam_stdlib", version = "0.37.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5398BD6C2ABA17338F676F42F404B9B7BABE1C8DC7380031ACB05BBE1BCF3742" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "file_streams", version = "0.6.3", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "file_streams", source = "hex", outer_checksum = "EC0DA36A4A5A79EB1281DD21247F062AD64D171D53C06ED4B4F520B0BC77F710" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "1.0.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "960090C2FB391784BB34267B099DC9315CC1B1F6013E7415BC763CEF1905D7D3" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "gleescript", version = "1.5.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "gleam_erlang", "gleam_stdlib", "simplifile", "snag", "tom"], otp_app = "gleescript", source = "hex", outer_checksum = "27AC58481742ED29D9B37C506F78958A8AD798750A79ED08C8F8AFBA8F23563B" },
+  { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
 argv = { version = ">= 1.0.2 and < 2.0.0" }
 file_streams = { version = ">= 0.4.2 and < 1.0.0" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_stdlib = { version = "~> 1.0" }
+gleescript = { version = ">= 1.4.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/starter_templates/gleam/code/src/main.gleam
+++ b/starter_templates/gleam/code/src/main.gleam
@@ -1,6 +1,6 @@
 import argv
-import file_streams/read_stream
-import gleam/int.{to_string}
+import file_streams/file_stream
+import gleam/int
 import gleam/io
 
 pub fn main() {
@@ -12,14 +12,19 @@ pub fn main() {
   // TODO: Uncomment the code below to pass the first stage
   // case args {
   //   [database_file_path, ".dbinfo", ..] -> {
-  //     let assert Ok(rs) = read_stream.open(database_file_path)
-  //     // Skip the first 16 bytes
-  //     let assert Ok(_bytes) = read_stream.read_bytes_exact(rs, 16)
+  //     let assert Ok(stream) = file_stream.open_read(database_file_path)
+  //     // Skip the first 16 bytes of the header
+  //     let assert Ok(_skip) = file_stream.read_bytes_exact(stream, 16)
   //     // The next 2 bytes hold the page size in big-endian format
-  //     let assert Ok(page_size) = read_stream.read_uint16_be(rs)
+  //     let assert Ok(header) = file_stream.read_bytes_exact(stream, 2)
+  //     let page_size = case header {
+  //       <<hi, lo>> -> hi * 256 + lo
+  //       _ -> 0
+  //     }
+  //     let assert Ok(Nil) = file_stream.close(stream)
   //
   //     io.print("database page size: ")
-  //     io.println(to_string(page_size))
+  //     io.println(int.to_string(page_size))
   //   }
   //   _ -> {
   //     io.println("Unknown command")


### PR DESCRIPTION
CC-2274: Upgrade Gleam to v0.16

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the Gleam toolchain version, dependency set, and the compile/run pipeline (now producing/executing a `main` binary), which could break builds or runtime behavior if the new tooling differs.
> 
> **Overview**
> Upgrades the Gleam track to **Gleam 1.16** (including a new `dockerfiles/gleam-1.16.Dockerfile`) and updates `gleam.toml`/`manifest.toml` to match (stdlib pinned to `~> 1.0`, refreshed package versions, and adds `gleescript` as a dev dependency).
> 
> Changes the CodeCrafters and local scripts to run `gleam run -m gleescript` during compile and then execute the generated `./main` binary at runtime (and ignores `main` in `.gitignore`).
> 
> Updates the example `main.gleam` code (starter + solution) to use `file_streams/file_stream` APIs and manually parse the 2-byte page size header instead of the previous `read_stream` helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49ef6b9e81438e08db342b19bb441397b7cfb746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->